### PR TITLE
Добавление необходимого расширения для класса Vector

### DIFF
--- a/SpaceBattle.Lib/VectorExtentions.cs
+++ b/SpaceBattle.Lib/VectorExtentions.cs
@@ -1,0 +1,11 @@
+﻿namespace SpaceBattle.Lib;
+using System.Reflection;
+
+public static class VectorExtensions
+{
+    public static int[] GetCoordinates(this Vector vector)
+    {
+        var field = typeof(Vector).GetField("coordinates", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (int[])field!.GetValue(vector)!;
+    }
+}

--- a/SpaceBattle.Tests/VectorExtentionsTest.cs
+++ b/SpaceBattle.Tests/VectorExtentionsTest.cs
@@ -1,0 +1,20 @@
+﻿using SpaceBattle.Lib;
+
+namespace SpaceBattle.Tests;
+
+public class VectorExtentionsTest
+{
+    [Fact]
+    public void TestPositive()
+    {
+        int[] nums = { 2, 3 };
+        var VectorObj = new Vector(2, 3);
+        Assert.Equal(nums, VectorObj.GetCoordinates());
+    }
+    [Fact]
+    public void TestPositiveEmpty()
+    {
+        var VectorObj = new Vector();
+        Assert.Equal([], VectorObj.GetCoordinates());
+    }
+}


### PR DESCRIPTION
Данный Pull request необходим для дальнейшей работы с классом Vector. Создан в связи с закрытием (модификатор private) представления Vector (coordinates) в виде массива int (int[]). 